### PR TITLE
Fix ./autogen.sh: line 8: [: missing `]'

### DIFF
--- a/{{cookiecutter.project_name|lower}}/autogen.sh
+++ b/{{cookiecutter.project_name|lower}}/autogen.sh
@@ -5,7 +5,7 @@ set -e
 chmod +x $0
 chmod +x ./get-version
 
-[ ! -f .gitmodules ] || [ ! -e .git ]] || {
+[ ! -f .gitmodules ] || [ ! -e .git ] || {
     echo "autogen.sh: updating git submodules"
     git submodule init
     git submodule update


### PR DESCRIPTION
Currently, when I run `autogen.sh` I get the following error :
```
./autogen.sh: line 8: [: missing `]'
```

By removing the extra `]` character, the issue has been fixed.